### PR TITLE
Remove extra 'see' in the generated info

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -23,6 +23,7 @@ python_info: python_src sphinx-build
 
 python.texi: python_info python_info/python.texi Makefile
 	sed -e 's/@dircategory Documentation tools/@dircategory Programming/g' \
+		-e 's/@pxref{/@ref{/g' \
 		python_info/python.texi > $@
 
 .PHONY: python_texinfo

--- a/build/Makefile
+++ b/build/Makefile
@@ -18,10 +18,15 @@ sphinx_env:
 sphinx-build: sphinx_env
 	sphinx_env/bin/pip install sphinx==1.1.3
 
-python_texinfo: python_src sphinx-build
+python_info: python_src sphinx-build
 	sphinx_env/bin/sphinx-build -b texinfo python_src/Doc python_info
-	sed -i 's/@dircategory Documentation tools/@dircategory Programming/g' python_info/python.texi
-	cp python_info/python.texi python.texi
+
+python.texi: python_info python_info/python.texi Makefile
+	sed -e 's/@dircategory Documentation tools/@dircategory Programming/g' \
+		python_info/python.texi > $@
+
+.PHONY: python_texinfo
+python_texinfo: python.texi
 
 clean:
 	rm -f python.tgz
@@ -31,7 +36,7 @@ clean:
 	rm -f python.texi
 	rm -f python.info
 
-python.info:
+python.info: python.texi
 	makeinfo --no-split python.texi
 
 install: python.info

--- a/build/Makefile
+++ b/build/Makefile
@@ -29,8 +29,11 @@ clean:
 	rm -rf python_info
 	rm -rf sphinx_env
 	rm -f python.texi
+	rm -f python.info
 
-install:
+python.info:
 	makeinfo --no-split python.texi
-	cp python.info /usr/share/info
+
+install: python.info
+	cp $< /usr/share/info
 	install-info --info-dir=/usr/share/info python.info


### PR DESCRIPTION
The texinfo generated by sphinx uses `@pxref` while `@ref` works better for this documentation.

Also reworked the Makefile a bit to facilitate this change. 